### PR TITLE
update Freifunk video

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,7 @@ layout: base
 
 <!-- First Band (Image) -->
 
-<div class="teaser">
-  <div class="row">
-    <div class="eight columns">
-      <div id="flash_placeholder">
-        <video poster="images/freifunk_verbindet_sd.png" style="width: 100%; height: 100%" controls>
-          <source src="videos/freifunk_verbindet_sd.mp4" type="video/mp4" />
-          <source src="videos/freifunk_verbindet_sd.webm" type="video/webm" />
-          <source src="videos/freifunk_verbindet_sd.ogv" type="video/ogg" />
-          Your browser does not support the video tag.
-        </video>
-      </div>
-    </div>
+<div class="responsive-video"><iframe src="https://player.vimeo.com/video/124625767?title=0&byline=0&portrait=0&autoplay=0" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><br></p>
     <div class="four columns">
       <div class="panel">
         <p>


### PR DESCRIPTION
Nun wird das FF Video von Vimeo geladen.

Das hat den Vorteil, dass es nicht vor Browser vorgeladen wird was gerade beim mobilen Seitenaufbau massiv Datenvolumen einspart.
