### PR TITLE
Impressum auf Offene Netze Nord e.V. geändert

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -17,31 +17,29 @@ layout: base
       <p><a href="mailto:{{ site.community.mail_info }}">{{ site.community.mail_info }}</a></p>
       <h3>Angaben gemäß § 5 TMG</h3>
       <p>
-        Förderverein Freie Netzwerke e. V.<br>
-        c/o Rabener/Rau<br>
-        Stephanstr. 10<br>
-        10559 Berlin
+        Offene Netze Nord e. V.<br>
+        Ruben Barkow<br>
+        Fraunhoferstr. 2-4<br>
+        24118 Kiel<br>
       </p>
-      <p>Webseite: <a href="http://foerderverein.freie-netzwerke.de">foerderverein.freie-netzwerke.de</a><br>
+      <p>Webseite: <a href="http://www.offene-netze.de">www.offene-netze.de</a><br>
       Telefon: +49 (0)30 53014673<br>
-      E-Mail: mail{at}foerderverein.freie-netzwerke.de</p>
+      E-Mail: onn{at}offene-netze.de</p>
       <h3>Vertreten durch den Vorstand</h3>
       <p>
-      Monic Meisel<br>
-      Iris Rabener<br>
-      Jürgen Neumann<br>
-      Christian Heise</p>
+      Ruben Barkow>
+      Felix von Courten<br>
+      Nils Schneider<br>
       </p>
       <h3>Registereintrag</h3>
       <p>
-      Registergericht: Amtsgericht Berlin Charlottenburg<br>
-      Registernummer: VR 22961</p>
+      Registergericht: Amtsgericht xxxxx<br>
+      Registernummer: xxxxxxx</p>
       <h3>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h3>
       <p>
-      Dr. Olaf Koglin<br>
-      Rechtsanwalt<br>
-      An der Aussicht 40<br>
-      13503 Berlin</p>
+      Ruben Barkow<br>
+      xxxxbr>
+      xxxxx</p>
     </div>
   </div>
   <div class="six columns">


### PR DESCRIPTION
xxx müssen noch ersetzt werden
