### PR TITLE
disable video preload

### DIFF
--- a/firmware.html
+++ b/firmware.html
@@ -16,7 +16,7 @@ layout: base
     <p>	Bei fragen, komme in den IRC Chat hackint.org #ffnord oder oben unseren Webchat.
     </p>
     <p>Hier findest du eine Liste unterstützter Router-Modelle und ihre entsprechenden Firmwares.</p>
-    <p><b>Achtung!</b> Beim Umstieg von einer anderen Firmware aus einer anderen Community unbedingt den Haken "Einstellungen behalten" 
+    <p><b>Achtung!</b> Beim Umstieg von einer anderen Firmware aus einer anderen Community unbedingt den Haken "Einstellungen behalten"
 	ausschalten, also alle Einstellungen vergessen! Die Nord Firmware kann die Einstlellungen nicht korrekt übernehmen.</p>
     <p><strong>Aktuelle Firmware-Version: {{ site.firmware_version }}</strong></p>
   </div>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: base
   <div class="row">
     <div class="eight columns">
       <div id="flash_placeholder">
-        <video poster="images/freifunk_verbindet_sd.png" style="width: 100%; height: 100%" controls>
+        <video poster="images/freifunk_verbindet_sd.png" style="width: 100%; height: 100%" controls preload="none">
           <source src="videos/freifunk_verbindet_sd.mp4" type="video/mp4" />
           <source src="videos/freifunk_verbindet_sd.webm" type="video/webm" />
           <source src="videos/freifunk_verbindet_sd.ogv" type="video/ogg" />

--- a/index.html
+++ b/index.html
@@ -8,19 +8,12 @@ layout: base
   <div class="row">
     <div class="eight columns">
       <div id="flash_placeholder">
-        <a id="video_starter" title="2x klicken zum Starten" href="#video" onclick="add_video();return false" onmouseover="add_video()">Start Video (benötigt Javascript)</a>
-        <script>
-            function add_video(){
-                v='<video poster="images/freifunk_verbindet_sd.png" style="max-height:336px;width: 100%; height: 100%" controls>';
-                  v+='<source src="videos/freifunk_verbindet_sd.mp4" type="video/mp4" />';
-                  v+='<source src="videos/freifunk_verbindet_sd.webm" type="video/webm" />';
-                  v+='<source src="videos/freifunk_verbindet_sd.ogv" type="video/ogg" />';
-                  v+='Your browser does not support the video tag.';
-                v+='</video>';
-                document.getElementById("flash_placeholder").style.background='transparent';
-                document.getElementById("flash_placeholder").innerHTML=v;
-            }
-        </script>
+        <video poster="images/freifunk_verbindet_sd.png" style="width: 100%; height: 100%" controls>
+          <source src="videos/freifunk_verbindet_sd.mp4" type="video/mp4" />
+          <source src="videos/freifunk_verbindet_sd.webm" type="video/webm" />
+          <source src="videos/freifunk_verbindet_sd.ogv" type="video/ogg" />
+          Your browser does not support the video tag.
+        </video>
       </div>
     </div>
     <div class="four columns">
@@ -49,7 +42,7 @@ layout: base
 		<!--  Raw HTML content: [end] -->
 			</div>
 	<!--  CONTENT ELEMENT, uid:161/html [end] -->
-<br>Schau ob in deiner Nähe schon eine Community besteht (noch nicht auf der Karte, 
+<br>Schau ob in deiner Nähe schon eine Community besteht (noch nicht auf der Karte,
 aber auch im Freifunk Nord Gebiet sind die angrenzenden Kommunen südlich von Hamburg, dort gibt es z.B. schon <a href="http://freifunk-lueneburg.de/">Freifunk Lüneburg</a>).</p>
     <p>Weitere Karten:<ul>
       <li><a href="http://www.freifunk-karte.de">Freifunk Karte</li>

--- a/stylesheets/app.css
+++ b/stylesheets/app.css
@@ -21,19 +21,9 @@ div.header {
 #flash_placeholder {
   background:url('../images/flash_placeholder.png');
   min-height:330px;
-  max-height: 330px;
   margin-bottom:10px;
   background-repeat:no-repeat;
   max-width: 100%;
-}
-
-#video_starter{
-	display:block;
-	width:100%;
-	height:100%;
-	min-width: 590px;
-	min-height: 340px;
-	color:transparent
 }
 
 .firmwarelist {


### PR DESCRIPTION
Dieser Commit bezieht sich auf #1 

Mir gefallen beide Lösungen dort nicht. Von Vimeo würde ich es auch nicht laden. Aber auch dieses onclick ist irgendwie gehackt. Es gibt für `<video>` und `<audio>` ein [`prefetch` Attribut](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes).

@rubo77 was sagst du dazu?
