### PR TITLE
Webchat rechts

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -48,8 +48,8 @@
         <li><a href="/firmware.html">Firmware</a></li>
         <li><a href="/treffen.html">Treffen</a></li>
         <li><a href="{{ site.community.url_wiki }}">Wiki</a></li>
-        <li><a href="https://kiwiirc.com/client/irc.eu.hackint.org:+9999/ffnord?nick=ffnord-besucher" target="_blank">Webchat</a></li>
         <li><a href="https://forum.freifunk.net/c/meta-community/ffnord" target="_blank">Forum</a></li>
+        <li><a href="https://kiwiirc.com/client/irc.eu.hackint.org:+9999/ffnord?nick=ffnord-besucher" target="_blank">Webchat</a></li>
       </ul>
     </div>
     <style type="text/css">


### PR DESCRIPTION
Der Webchat steht jetzt ganz rechts wie von rubo77 gewünscht.
