### PR TITLE
Freifunk Hagen / Bad Bramstedt entfernt

### DIFF
--- a/treffen.html
+++ b/treffen.html
@@ -41,20 +41,6 @@ layout: base
   </div>
   <br>
   <div class="eight columns">
-    <h2>Freifunk Hagen / Bad Bramstedt</h2>
-    <p><strong>letzter Mittwoch im Monat, ab 20:00 Uhr</strong></p>
-    <p>Dorfhaus Hagen<br/>
-      <a href="https://www.openstreetmap.org/way/235202781" target="_blank">
-      Hitzhusener Straße 20a<br/>
-      24576 Hagen</a>
-    </p>
-    <ul>
-      <li><a href="http://www.ffhagen.de/">Freifunk Hagen</a></li>
-      <li><a href="http://www.freifunk-badbramstedt.de">Freifunk Bad Bramstedt</a></li>
-    </ul>
-  </div>
-  <br>
-  <div class="eight columns">
     <h2>Freifunk Nordheide</h2>
     <p><strong>1. Dienstag im Monat, ab 19:00 Uhr</strong></p>
     <a href="https://www.openstreetmap.org/node/3812556803" target="_blank">       


### PR DESCRIPTION
Die Treffen finden aktuell nicht mehr statt.